### PR TITLE
s/html-capture/viewport-capture/ doc policy to reflect Sept resolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,8 @@
                 [=top-level browsing context=]'s
                 <a href="https://wicg.github.io/document-policy/#required-document-policy">
                 required document policy</a> does not contain
-                `Require-Document-Policy: html-capture` (TODO: use correct algorithm),
+                `Require-Document-Policy: viewport-capture` and
+                `Document-Policy: viewport-capture` (TODO: use correct algorithm),
                 return a promise <a>rejected</a>
                 with a {{DOMException}} object whose {{DOMException/name}}
                 attribute has the value {{SecurityError}}.</p>


### PR DESCRIPTION
Reflects https://www.w3.org/2021/09/20-webrtc-minutes.html#r02 which postdates https://github.com/w3c/mediacapture-viewport/issues/1#issuecomment-912138999.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-viewport/pull/4.html" title="Last updated on Mar 12, 2022, 6:40 PM UTC (b704b1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-viewport/4/ea7fe46...jan-ivar:b704b1b.html" title="Last updated on Mar 12, 2022, 6:40 PM UTC (b704b1b)">Diff</a>