### PR TITLE
Replace usage of "responsible document"

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,8 +152,7 @@
                 attribute has the value {{SecurityError}}.</p>
               </li>
               <li>
-                If the [=relevant settings object=]'s
-                [=environment settings object/responsible document=]'s
+                If the [=relevant global object=]'s [=associated `Document`=]'s
                 [=top-level browsing context=]'s
                 <a href="https://wicg.github.io/document-policy/#required-document-policy">
                 required document policy</a> does not contain
@@ -221,7 +220,8 @@
                 value or a value of <code>true</code>.</p>
               </li>
               <li>
-                <p>If the <a>current settings object</a>'s [=environment settings object/responsible document=] is NOT [=Document/fully active=] or does NOT
+                <p>If the [=relevant global object=]'s [=associated `Document`=]
+                is NOT [=Document/fully active=] or does NOT
                 <a data-cite="!HTML/#gains-focus">have focus</a>, return
                   a promise [=reject|rejected=] with a
                   {{DOMException}} object whose
@@ -267,19 +267,16 @@
                     MUST be a live-capture of the
                     <a data-cite="SCREEN-CAPTURE#dfn-browser">browser</a>
                     <a data-cite="SCREEN-CAPTURE#dfn-display-surface">display surface</a>
-                    of the [=relevant settings object=]'s
-                    [=environment settings object/responsible document=]'s
+                    of the [=relevant global object=]'s [=associated `Document`=]'s
                     [=top-level browsing context=]'s
                     <a data-cite="HTML#viewport">viewport</a>.</p>
                     <p>The provided media MUST include at most one audio track, which, if
                     provided, MUST be the combined audio produced by the sum of
                     documents that consist of the
-                    [=relevant settings object=]'s
-                    [=environment settings object/responsible document=]'s
+                    [=relevant global object=]'s [=associated `Document`=]'s
                     [=top-level browsing context=]'s [=active document=], and
                     all [=active document=]s in [=nested browsing context=]s of
-                    the [=relevant settings object=]'s
-                    [=environment settings object/responsible document=]'s
+                    the [=relevant global object=]'s [=associated `Document`=]'s
                     [=top-level browsing context=]. This audio track
                     MUST NOT be included if audio was not specified in
                     <var>requestedMediaTypes</var>, or if it was specified as


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 3, 2022, 10:10 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fmediacapture-viewport%2Fbcdcacbc91611a3f0a7cd4066ebea9c2675815f5%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 404: http://labs.w3.org/spec-generator/uploads/7yKNRc
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/mediacapture-viewport%2318.)._
</details>
