### PR TITLE
s/...Constraints/...Options

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
         <pre class="idl"
 >partial interface MediaDevices {
   Promise&lt;MediaStream&gt; getViewportMedia(
-      optional DisplayMediaStreamConstraints constraints = {});
+      optional DisplayMediaStreamOptions options = {});
 };</pre>
         <dl data-link-for="MediaDevices" data-dfn-for="MediaDevices" class="methods">
           <dt>
@@ -117,7 +117,7 @@
           <dd>
             <p>Prompts the user for permission to live-capture the viewport (current tab).</p>
             <p>
-              The user agent MUST apply any provided <var>constraints</var> to the produced
+              The user agent MUST apply any provided <var>options</var> to the produced
               media after permission has been granted.
             </p>
             <p>
@@ -164,17 +164,17 @@
                 attribute has the value {{InvalidStateError}}.</p>
               </li>
               <li>
-                <p>Let <var>constraints</var> be the method's first
+                <p>Let <var>options</var> be the method's first
                 argument.</p>
               </li>
               <li>
-                <p>If <code>constraints.video</code> is <code>false</code>,
+                <p>If <code>options.video</code> is <code>false</code>,
                   return a promise [=reject|rejected=] with a newly
                   [=exception/created=] {{TypeError}}.</p>
               </li>
               <li>
                 <p>For each [= map/exist | existing =] member
-                in <var>constraints</var> whose value, <var>CS</var>, is
+                in <var>options</var> whose value, <var>CS</var>, is
                 a dictionary, run the following steps:</p>
                 <ol>
                   <li>
@@ -211,7 +211,7 @@
               </li>
               <li>
                 <p>Let <var>requestedMediaTypes</var> be the set of media
-                types in <var>constraints</var> with either a dictionary
+                types in <var>options</var> with either a dictionary
                 value or a value of <code>true</code>.</p>
               </li>
               <li>


### PR DESCRIPTION
Following https://github.com/w3c/mediacapture-screen-share/pull/229, `DisplayMediaStreamConstraints` is no longer recognized. This editorial PR updates the name here too.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-viewport/pull/26.html" title="Last updated on Sep 26, 2024, 9:50 PM UTC (6bfbe15)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-viewport/26/b3be9e3...eladalon1983:6bfbe15.html" title="Last updated on Sep 26, 2024, 9:50 PM UTC (6bfbe15)">Diff</a>