### PR TITLE
Set [Restrictable] on the video track

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,8 +325,7 @@
                     Let <var>videoTrack</var> be the video track in <var>stream</var>.
                   </li>
                   <li>
-                    <!-- TODO: Use spec-linking after merging https://github.com/w3c/mediacapture-main/pull/1015. -->
-                    Set <var>videoTrack</var>.<code>[Restrictable]</code> to <code>true</code>.
+                    Set <var>videoTrack</var>.{{MediaStreamTrack/[[Restrictable]]}} to <code>true</code>.
                   </li>
                   <li>
                     <p><a>Resolve</a> <var>p</var> with <var>stream</var> and

--- a/index.html
+++ b/index.html
@@ -322,6 +322,13 @@
                     <var>message</var>)</code>.</p>
                   </li>
                   <li>
+                    Let <var>videoTrack</var> be the video track in <var>stream</var>.
+                  </li>
+                  <li>
+                    <!-- TODO: Use spec-linking after merging https://github.com/w3c/mediacapture-main/pull/1015. -->
+                    Set <var>videoTrack</var>.<code>[Restrictable]</code> to <code>true</code>.
+                  </li>
+                  <li>
                     <p><a>Resolve</a> <var>p</var> with <var>stream</var> and
                     abort these steps.</p>
                   </li>


### PR DESCRIPTION
This marks video tracks obtained using getViewportMedia() as eligible tracks for [Element Capture](https://screen-share.github.io/element-capture/).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-viewport/pull/31.html" title="Last updated on Oct 9, 2024, 11:27 AM UTC (17ab171)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-viewport/31/976a130...eladalon1983:17ab171.html" title="Last updated on Oct 9, 2024, 11:27 AM UTC (17ab171)">Diff</a>